### PR TITLE
add freedesktop.org desktop entry

### DIFF
--- a/bpm.desktop
+++ b/bpm.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Version=1.0
+Name=Blue Pink Metronome
+GenericName=Metronome
+Comment=Keep in time
+Exec=/usr/bin/bpm
+Icon=bpm
+Terminal=false
+Type=Application
+Categories=Audio;Utility;
+Keywords=Player;Capture;DVD;Audio;Video;Server;Broadcast;


### PR DESCRIPTION
Added a desktop entry to optionally be installed to "/usr/share/applications" or "~/.local/share/applications"

This allows the program to be categorized in various desktop software's application launchers